### PR TITLE
fix: avatar type parsing and add invalid-token renewal mechanism

### DIFF
--- a/AirMute/AuthenticationController.swift
+++ b/AirMute/AuthenticationController.swift
@@ -4,13 +4,17 @@ extension RPC {
     func authenticateOverRPC() throws -> ResponseAuthenticate {
         if let tokenExpiry = UserDefaults.standard.object(forKey: "token_expiry") as? Date, tokenExpiry > Date() {
             if let accessTokenData = UserDefaults.standard.data(forKey: "access_token") {
-                logger.info("Loaded cached credentials")
-                let accessToken = try AccessToken.from(data: accessTokenData)
-                return try authenticate(accessToken: accessToken.accessToken)
+                do {
+                    logger.info("Loaded cached credentials")
+                    let accessToken = try AccessToken.from(data: accessTokenData)
+                    return try authenticate(accessToken: accessToken.accessToken)
+                } catch {
+                    logger.warning("Cached credentials were found, but they are invalid. Re-authenticating...")
+                }
             }
         }
         
-        logger.info("Credentials expired, reauthenticating...")
+        logger.info("Credentials expired or invalid, reauthenticating...")
         
         let authorization = try authorize(oAuth2Scopes: [.rpc, .rpcVoiceRead, .rpcVoiceWrite, .identify])
         let accessToken = try fetchAccessToken(code: authorization.data.code, redirectURI: "http://localhost")

--- a/AirMute/RPC/Types/User.swift
+++ b/AirMute/RPC/Types/User.swift
@@ -5,13 +5,18 @@ private enum UserError: Error {
     case userHasNoAvatar
 }
 
+public struct AvatarDecorationData: Codable {
+    public let asset: String
+    public let skuId: String?
+}
+
 public class User: Codable {
     public let id: String
     public let username: String
     public let globalName: String
     public let discriminator: String
     public let avatar: String?
-    public let avatarDecorationData: String?
+    public let avatarDecorationData: AvatarDecorationData?
     public let bot: Bool?
     public let system: Bool?
     public let mfaEnabled: Bool?


### PR DESCRIPTION
## Issues
In my case, I encountered two issues when testing the application:
1. The status would remain “Trying to connect…” indefinitely and never progressed or fell into an error state.
2. Once I resolved the first issue, I removed the permission to test the entire flow again, and then the app could no longer request the necessary permission.


##  Solutions 
1. The issue here was simple: I use Discord’s paid version, so my avatar included a decoration. The user type expected the avatar to be a string, but in these cases the avatar is an object, which broke the code. To fix this, I created a new type that accepts this pattern.
2. After the app detected that it had already requested permission from Discord, there was no reauthentication logic. I implemented this so that—even if a token already exists—if it’s invalid, a new one is automatically generated. This could also help design a better flow for issue #2 in the future.

## Observations
I tested the full flow both with and without avatar decorations to simulate a non-paid account, but I’m not sure if it produces the same effect. It would be good to test again to confirm that everything is working.

I’m available if you need anything 🚀❤️